### PR TITLE
Add animation to header bee and fix page being too long

### DIFF
--- a/dist/main.css
+++ b/dist/main.css
@@ -165,6 +165,31 @@ header #title {
 #title-bee {
   height: 50px;
   padding-left: 10px;
+  transition: all 1s ease-in-out;
+}
+
+#title-bee:hover {
+  animation: bounce 0.5s infinite;
+  transform-origin: center;
+  transition: all 0.2s ease-in-out;
+}
+
+@keyframes bounce {
+  0% {
+    transform: scale(1);
+  }
+  25% {
+    transform: translate3d(0, -3px, 0) scale(1.1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  75% {
+    transform: translate3d(0, -3px, 0) scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 #tagline {
@@ -247,13 +272,12 @@ footer {
   position: absolute;
   top: 106px;
   z-index: 10;
-  border: 1px solid white;
 }
 
 #announcement-white {
   display: block;
   width: 1200px;
-  height: 600px;
+  height: 602px;
   object-fit: cover;
   border-radius: 10px;
 }
@@ -263,6 +287,7 @@ footer {
   top: -550px;
   line-height: 60px;
   padding-left: 50px;
+  height: 400px;
 }
 
 #welcome-text H1 {

--- a/index.html
+++ b/index.html
@@ -37,8 +37,9 @@
     <header>
       <div id="title-div">
         <h1 id="title">Bouncy Bee</h1>
-        <a href="https://github.com/taisiat/bouncy-bee"><img src="assets/bee/keyframes/side_view_bee_fly_r_000.png" id="title-bee" >
-</a>
+        <a href="https://github.com/taisiat/bouncy-bee" target="_blank">
+          <img src="assets/bee/keyframes/side_view_bee_fly_r_000.png" id="title-bee" >
+        </a>
       </div>
       <div id="tagline">
         <h2>TAISIA KARASEVA</h2>


### PR DESCRIPTION
Header bee now bounces when hovered and takes to project github. Page is no longer "long".